### PR TITLE
chore: enforce repo ownership and PR governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# OpenAgriNet ownership for oan-ai-api
+# Source: Openagrinet-repo-ownership-and-pr-governance.pdf
+* @smrit18 @addypy

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- What changed and why? Keep this concise and specific. -->
+
+## Branch Type
+
+- [ ] `feature/<short-name>`
+- [ ] `bugfix/<short-name>`
+- [ ] `hotfix/<short-name>`
+- [ ] `chore/<short-name>`
+
+## Governance Checklist
+
+- [ ] This PR targets a protected base branch through a pull request (no direct push).
+- [ ] Branch naming follows the approved pattern.
+- [ ] The PR is focused and does not mix unrelated changes.
+- [ ] I will not approve my own PR.
+- [ ] At least 1 peer approval is present before merge.
+- [ ] At least 1 CODEOWNERS approval is present before merge.
+- [ ] All review comments/threads are resolved before merge.
+- [ ] I understand approvals must be refreshed after new commits are pushed.
+
+## Emergency Fix (Only if Applicable)
+
+- [ ] This is an emergency production change.
+- [ ] If admin bypass is used, post-merge review will be completed within 24 hours.

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -1,0 +1,200 @@
+name: PR Governance Gate
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - edited
+  pull_request_review:
+    types:
+      - submitted
+      - edited
+      - dismissed
+  pull_request_review_thread:
+    types:
+      - resolved
+      - unresolved
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  governance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Enforce governance policy
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+
+            const protectedBranches = new Set(["main", "master", "mh-main", "bh-main"]);
+            const branchPattern = /^(feature|bugfix|hotfix|chore)\/[A-Za-z0-9._-]+$/;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+
+            if (!pr) {
+              core.setFailed("No pull request payload found in event context.");
+              return;
+            }
+
+            if (!protectedBranches.has(pr.base.ref)) {
+              core.info(`Skipping governance checks for non-protected base branch: ${pr.base.ref}`);
+              return;
+            }
+
+            const failures = [];
+            const prAuthor = (pr.user?.login || "").toLowerCase();
+            const isBotPr = pr.user?.type === "Bot" || (pr.user?.login || "").endsWith("[bot]");
+
+            if (!isBotPr && !branchPattern.test(pr.head.ref)) {
+              failures.push(
+                `Branch "${pr.head.ref}" does not match required naming: feature/<short-name>, bugfix/<short-name>, hotfix/<short-name>, chore/<short-name>.`
+              );
+            }
+
+            const codeownersPath = path.join(process.env.GITHUB_WORKSPACE || ".", ".github", "CODEOWNERS");
+            let codeownerUsers = [];
+            if (!fs.existsSync(codeownersPath)) {
+              failures.push("Missing .github/CODEOWNERS file.");
+            } else {
+              const content = fs.readFileSync(codeownersPath, "utf8");
+              codeownerUsers = Array.from(
+                new Set(
+                  content
+                    .split(/\r?\n/)
+                    .map((line) => line.trim())
+                    .filter((line) => line && !line.startsWith("#"))
+                    .flatMap((line) => line.split(/\s+/).slice(1))
+                    .filter((ownerToken) => ownerToken.startsWith("@"))
+                    .map((ownerToken) => ownerToken.slice(1).toLowerCase())
+                    .filter((ownerToken) => !ownerToken.includes("/"))
+                )
+              );
+              if (codeownerUsers.length === 0) {
+                failures.push("No individual CODEOWNERS users found. Add at least one @username in .github/CODEOWNERS.");
+              }
+            }
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100
+            });
+
+            const latestReviewByUser = new Map();
+            for (const review of reviews) {
+              const login = review.user?.login?.toLowerCase();
+              if (!login || !review.submitted_at) {
+                continue;
+              }
+
+              const existing = latestReviewByUser.get(login);
+              if (!existing) {
+                latestReviewByUser.set(login, review);
+                continue;
+              }
+
+              const reviewTime = new Date(review.submitted_at).getTime();
+              const existingTime = new Date(existing.submitted_at).getTime();
+              if (reviewTime >= existingTime) {
+                latestReviewByUser.set(login, review);
+              }
+            }
+
+            const effectiveReviews = Array.from(latestReviewByUser.values());
+            const approvals = effectiveReviews.filter((review) => review.state === "APPROVED");
+            const peerApprovals = approvals.filter(
+              (review) => review.user?.login?.toLowerCase() !== prAuthor
+            );
+            const selfApprovals = reviews.filter(
+              (review) =>
+                review.state === "APPROVED" &&
+                review.user?.login?.toLowerCase() === prAuthor
+            );
+
+            if (selfApprovals.length > 0) {
+              failures.push("PR author approval detected. Authors cannot approve their own pull request.");
+            }
+
+            if (peerApprovals.length < 1) {
+              failures.push("At least one peer approval is required.");
+            }
+
+            const latestCommitApprovals = peerApprovals.filter((review) => review.commit_id === pr.head.sha);
+            if (latestCommitApprovals.length < 1) {
+              failures.push("No peer approval found on the latest commit. Re-approval is required after new commits.");
+            }
+
+            if (codeownerUsers.length > 0) {
+              const codeownerApprovals = peerApprovals.filter((review) =>
+                codeownerUsers.includes(review.user?.login?.toLowerCase() || "")
+              );
+              if (codeownerApprovals.length < 1) {
+                failures.push("At least one CODEOWNERS approval is required.");
+              } else {
+                const codeownerLatestCommitApprovals = codeownerApprovals.filter(
+                  (review) => review.commit_id === pr.head.sha
+                );
+                if (codeownerLatestCommitApprovals.length < 1) {
+                  failures.push("No CODEOWNERS approval found on the latest commit.");
+                }
+              }
+            }
+
+            let unresolvedThreads = 0;
+            let cursor = null;
+            do {
+              const data = await github.graphql(
+                `
+                  query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+                    repository(owner: $owner, name: $repo) {
+                      pullRequest(number: $number) {
+                        reviewThreads(first: 100, after: $cursor) {
+                          nodes {
+                            isResolved
+                          }
+                          pageInfo {
+                            hasNextPage
+                            endCursor
+                          }
+                        }
+                      }
+                    }
+                  }
+                `,
+                {
+                  owner,
+                  repo,
+                  number: pr.number,
+                  cursor
+                }
+              );
+
+              const reviewThreads = data.repository.pullRequest.reviewThreads;
+              unresolvedThreads += reviewThreads.nodes.filter((thread) => !thread.isResolved).length;
+              cursor = reviewThreads.pageInfo.hasNextPage ? reviewThreads.pageInfo.endCursor : null;
+            } while (cursor);
+
+            if (unresolvedThreads > 0) {
+              failures.push(`There are ${unresolvedThreads} unresolved review thread(s).`);
+            }
+
+            if (failures.length > 0) {
+              core.setFailed(
+                `PR governance checks failed:\n- ${failures.join("\n- ")}`
+              );
+              return;
+            }
+
+            core.info("PR governance checks passed.");

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -13,11 +13,6 @@ on:
       - submitted
       - edited
       - dismissed
-  pull_request_review_thread:
-    types:
-      - resolved
-      - unresolved
-
 permissions:
   contents: read
   pull-requests: read

--- a/docs/repo-governance-enforcement.md
+++ b/docs/repo-governance-enforcement.md
@@ -1,0 +1,53 @@
+# OpenAgriNet Governance Enforcement
+
+This repository enforces the policy in `Openagrinet-repo-ownership-and-pr-governance.pdf` with:
+
+1. `CODEOWNERS` ownership mapping.
+2. Pull request template checklist.
+3. Automated PR governance checks in GitHub Actions.
+4. Scripted branch protection for protected branches.
+
+## What Is Enforced In-Repo
+
+- Owners are defined in `.github/CODEOWNERS`.
+- PRs into protected branches are validated by `.github/workflows/pr-governance.yml` for:
+  - branch name pattern (`feature/`, `bugfix/`, `hotfix/`, `chore/`)
+  - no self-approval
+  - at least one peer approval
+  - at least one CODEOWNERS approval
+  - re-approval on latest commit
+  - all review threads resolved
+
+## Apply GitHub Branch Protection
+
+Run:
+
+```bash
+bash scripts/apply_repo_governance.sh
+```
+
+Optional explicit target repo:
+
+```bash
+bash scripts/apply_repo_governance.sh <org>/<repo>
+```
+
+### Script Requirements
+
+- `gh` installed and authenticated (`gh auth login`)
+- admin access to the target repository
+- `jq` installed
+
+### Script Applies These Settings
+
+For branches that exist among `main`, `master`, `mh-main`, `bh-main`:
+
+- pull-request reviews required (minimum 1 approval)
+- CODEOWNERS review required
+- stale approvals dismissed on new commits
+- last push requires approval from someone else
+- all conversations must be resolved
+- force pushes disabled
+- branch deletions disabled
+- admin enforcement enabled
+- required status check: `PR Governance Gate / governance`

--- a/scripts/apply_repo_governance.sh
+++ b/scripts/apply_repo_governance.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${1:-}"
+if [[ -z "$REPO" ]]; then
+  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Error: GitHub CLI (gh) is required."
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required."
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "Error: gh is not authenticated. Run: gh auth login"
+  exit 1
+fi
+
+PROTECTED_BRANCHES=("main" "master" "mh-main" "bh-main")
+STATUS_CONTEXTS='["PR Governance Gate / governance"]'
+
+echo "Applying OpenAgriNet governance to ${REPO}..."
+for branch in "${PROTECTED_BRANCHES[@]}"; do
+  resolved_branch="$(gh api "repos/${REPO}/branches/${branch}" --jq .name 2>/dev/null || true)"
+  if [[ "${resolved_branch}" != "${branch}" ]]; then
+    echo "Skipping missing branch: ${branch}"
+    continue
+  fi
+
+  payload="$(
+    jq -n \
+      --argjson contexts "${STATUS_CONTEXTS}" \
+      '{
+        required_status_checks: {
+          strict: true,
+          contexts: $contexts
+        },
+        enforce_admins: true,
+        required_pull_request_reviews: {
+          dismiss_stale_reviews: true,
+          require_code_owner_reviews: true,
+          required_approving_review_count: 1,
+          require_last_push_approval: true
+        },
+        restrictions: null,
+        required_linear_history: false,
+        allow_force_pushes: false,
+        allow_deletions: false,
+        required_conversation_resolution: true
+      }'
+  )"
+
+  gh api \
+    --method PUT \
+    -H "Accept: application/vnd.github+json" \
+    "repos/${REPO}/branches/${branch}/protection" \
+    --input - <<<"${payload}" >/dev/null
+
+  echo "Protected branch updated: ${branch}"
+done
+
+echo "Governance branch protection applied."


### PR DESCRIPTION
## Summary
Apply OpenAgriNet repo governance baseline from the approved policy document.

## Includes
- Add CODEOWNERS with primary + secondary ownership
- Add PR template governance checklist
- Add PR governance workflow checks
- Add branch-protection automation script
- Add governance enforcement docs

## Notes
Target branch is `dev` for staged rollout before moving to `main`.
